### PR TITLE
selected carousel on the show page

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -4,6 +4,7 @@ class ProfilesController < ApplicationController
   def me
     @collections = Collection.where(user: current_user)
     recommend_wine
+    set_first_user_collection
     # rendering the page to specific page
     render :show
   end
@@ -18,6 +19,10 @@ class ProfilesController < ApplicationController
     @wines = Wine.all
     @recommend_one = Wine.order('RANDOM()').first
     @recommend_two = Wine.order('RANDOM()').last
+  end
+
+  def set_first_user_collection
+    @first_user_collection = Collection.find(current_user.id)
   end
 
   private

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -22,7 +22,7 @@
     <%= link_to "Create your first personal Wine List", new_collection_path %>
   <% else %>
     <h3> Your <%= @first_user_collection.title %>
-      Wile list contains
+      Wine list contains
       <%= @first_user_collection.wine_ids.size %>
       wines. </h3>
   <% end %>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -14,10 +14,18 @@
 
 <div>
   <h3>Recommendations</h3>
-  <%#= cl_image_tag @recommend_one.photo.key %> <br>
-  <%#= @recommend_one.name %> <br>
-  <%#= cl_image_tag @recommend_two.photo.key %> <br>
-  <%#= @recommend_two.name %> <br>
-
   <%= render 'shared/recommendations', collections: @collections %>
+</div>
+
+<div>
+  <% if @first_user_collection == nil %>
+    <%= link_to "Create your first personal Wine List", new_collection_path %>
+  <% else %>
+    <h3> Your <%= @first_user_collection.title %>
+      Wile list contains
+      <%= @first_user_collection.wine_ids.size %>
+      wines. </h3>
+  <% end %>
+
+  <%= render 'shared/carousel' %>
 </div>

--- a/app/views/shared/_carousel.html.erb
+++ b/app/views/shared/_carousel.html.erb
@@ -11,7 +11,7 @@
     <% c = 1 %>
 
     <% while c < slides_total %>
-      <button type="button" data-bs-target="#carouselExampleCaptions2" data-bs-slide-to="<%= c %>" aria-label="Slide 2"></button>
+      <button type="button" data-bs-target="#carouselExampleCaptions2" data-bs-slide-to="<%= c %>" aria-label="Slide <%= c %>"></button>
       <% c += 1 %>
     <% end %>
 

--- a/app/views/shared/_carousel.html.erb
+++ b/app/views/shared/_carousel.html.erb
@@ -1,17 +1,17 @@
 <%# @first_user_collection.wine_ids => the wines in the list to display %>
 
-<div id="carouselExampleCaptions" class="carousel slide" data-bs-ride="carousel">
+<div id="carouselExampleCaptions2" class="carousel slide" data-bs-ride="carousel">
   <div class="carousel-indicators">
 
     <%# Buttons to be created based on the number of wines  %>
-    <button type="button" data-bs-target="#carouselExampleCaptions" data-bs-slide-to="0" class="active" aria-current="true" aria-label="Slide 1"></button>
+    <button type="button" data-bs-target="#carouselExampleCaptions2" data-bs-slide-to="0" class="active" aria-current="true" aria-label="Slide 1"></button>
 
     <%# slides-total = @first_user_collection.wine_ids.size %>
     <% slides_total = 5 %>
     <% c = 1 %>
 
     <% while c < slides_total %>
-      <button type="button" data-bs-target="#carouselExampleCaptions" data-bs-slide-to="<%= c %>" aria-label="Slide 2"></button>
+      <button type="button" data-bs-target="#carouselExampleCaptions2" data-bs-slide-to="<%= c %>" aria-label="Slide 2"></button>
       <% c += 1 %>
     <% end %>
 
@@ -56,11 +56,11 @@
       </div>
     </div> %>
   </div>
-  <button class="carousel-control-prev" type="button" data-bs-target="#carouselExampleCaptions" data-bs-slide="prev">
+  <button class="carousel-control-prev" type="button" data-bs-target="#carouselExampleCaptions2" data-bs-slide="prev">
     <span class="carousel-control-prev-icon" aria-hidden="true"></span>
     <span class="visually-hidden">Previous</span>
   </button>
-  <button class="carousel-control-next" type="button" data-bs-target="#carouselExampleCaptions" data-bs-slide="next">
+  <button class="carousel-control-next" type="button" data-bs-target="#carouselExampleCaptions2" data-bs-slide="next">
     <span class="carousel-control-next-icon" aria-hidden="true"></span>
     <span class="visually-hidden">Next</span>
   </button>


### PR DESCRIPTION
By default, the app grabs the first collection from the user to show (Working)
on the profile show page, it shows a carousel of the content of the profile page below the recommended wines (Partly working)
The carousel page is dynamically created in size based on the number of wines in the selected collection (working)

TODO:
- When there are NO wines in the collection, no need to show the carousel but ask the user to add wines to their lists
- Grab the correct wines based on the wine_ids in the collection