### PR TITLE
redirect user to create first collection list

### DIFF
--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -12,6 +12,7 @@ class CollectionsController < ApplicationController
 
   def new
     @collection = Collection.new
+    @bottle = params[:wine]
   end
 
   def create
@@ -19,10 +20,16 @@ class CollectionsController < ApplicationController
     @collection.user = current_user
 
     if @collection.save
+      add_wine_to_collection
       redirect_to me_profiles_path
     else
       render :new, status: :unprocessable_entity
     end
+  end
+
+  def add_wine_to_collection
+    @bottle = CollectionWine.new(collection_id: @collection.id, wine_id: params[:bottle])
+    @bottle.save
   end
 
   def edit

--- a/app/views/collections/_form.html.erb
+++ b/app/views/collections/_form.html.erb
@@ -1,4 +1,5 @@
 <%= simple_form_for(collection) do |f| %>
   <%= f.input :title %>
+  <%= hidden_field_tag 'bottle', @bottle %>
   <%= f.button :submit %>
 <% end %>

--- a/app/views/shared/_modal.html.erb
+++ b/app/views/shared/_modal.html.erb
@@ -35,9 +35,9 @@
             </ul>
           </div>
         <% else %>
-          <button class="btn btn-secondary" type="button" disabled>
-            Add to Collection
-          </button>
+          <div class="btn btn-secondary">
+            <%= link_to "Add to Collection", new_collection_path(:wine => wine.id), :class => "btn" %>
+          </div>
         <% end %>
       </div>
     </div>


### PR DESCRIPTION
The add to collection button is no longer disabled when there is no collection for the user yet, instead:

- the user is redirected to the create collection list page
- once successfully done, the app will automatically add the selected wine to the newly created collection
- user is redirected to profile/me