### PR TITLE
button remove from collection is showing

### DIFF
--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -6,6 +6,7 @@ class CollectionsController < ApplicationController
   end
 
   def show
+    @remove = params[:remove]
     @collections = Collection.all
     @collection = Collection.find(params[:id])
     @wines = @collection.wines

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -3,7 +3,7 @@
   <div class="my-collection gap-3 mb-3">
     <% @collections.each do |collection| %>
       <div class="list">
-      <%= link_to collection.title, user_collection_path(id: collection.id, user_id: current_user) %>
+      <%= link_to collection.title, user_collection_path(id: collection.id, user_id: current_user, :remove => true) %>
       <%= button_to '<i class="fa-solid fa-xmark"></i>'.html_safe, collection_path(id: collection.id),
       method: :delete, class: "btn btn-outline-warning", style: "margin-left: 5px; padding: 0px 2px; border: none;",
       form: { data: {turbo_confirm: 'Are you sure?'} } %>

--- a/app/views/shared/_modal.html.erb
+++ b/app/views/shared/_modal.html.erb
@@ -40,7 +40,7 @@
         <div class="modal-footer">
           <button type="button" class="btn btn-outline-warning" data-bs-dismiss="modal">Close</button>
         <% if !@collections.nil? %>
-          <% if @collections.size > 0 %>
+          <% if @collections.size > 0 && @remove.nil? %>
             <div class="dropdown">
               <button class="btn btn-warning dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">
                 Add to Collection
@@ -56,6 +56,11 @@
                 <% end %>
               </ul>
             </div>
+            <%# raise %>
+          <% elsif @remove == "true" %>
+            <button class="btn btn-warning dropdown-toggle" type="button" aria-expanded="false">
+                Remove from Collection
+            </button>
           <% else %>
             <%= link_to "Create a Collection", new_collection_path(:wine => wine.id), :class => "btn btn-warning" %>
           <% end %>


### PR DESCRIPTION
The "Remove from Collection" button is now showing when the Wine Information is selected from within a collection.
The other 2 features/user stories around this button are still working
- Create a Collection when there is NO collection yet for the user
- Add to collection, when the wine is selected as a recommendation and there are collections present