### PR TITLE
fixed collection title can not be blank

### DIFF
--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -2,4 +2,5 @@ class Collection < ApplicationRecord
   belongs_to :user
   has_many :collection_wines
   has_many :wines, through: :collection_wines
+  validates :title, presence: true
 end

--- a/app/views/collections/_form.html.erb
+++ b/app/views/collections/_form.html.erb
@@ -1,8 +1,8 @@
 <%= simple_form_for(collection) do |f| %>
   <%= f.input :title,
+              placeholder: 'enter the collection name',
               required: true,
-              autofocus: true,
-              hint: ("#{@minimum_password_length} characters minimum" if @minimum_password_length) %>
+              minlength: 1 %>
   <%= hidden_field_tag 'bottle', @bottle %>
   <%= f.button :submit %>
 <% end %>


### PR DESCRIPTION
Fixed the issue that the user could enter a blank collection name.

- Added validation in the model
- Added a placeholder to clarify what needs to be entered